### PR TITLE
Fix Node.js compatibility for Render deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "test": "test"
   },
   "engines": {
-    "node": "8.9.0",
-    "npm": "6.4.1"
+    "node": "16.x",
+    "npm": "8.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "echo 'Skipping webpack for now'",
-    "start": "NODE_OPTIONS=--openssl-legacy-provider webpack --watch --mode=development",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack"
+    "postinstall": "webpack",
+    "start": "webpack --watch --mode=development",
+    "build": "webpack --mode=production"
   },
   "repository": {
     "type": "git",

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     buildCommand: |
       bundle install
       npm ci --production=false || npm install
-      NODE_OPTIONS=--openssl-legacy-provider npm run build
+      npm run build
       RAILS_ENV=production bundle exec rake assets:precompile
       RAILS_ENV=production bundle exec rake db:migrate
     startCommand: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## 🔧 Node.js Compatibility Fix for Render

This PR fixes the Node.js compatibility issue that was preventing successful deployment on Render.

### 🚨 Fixes Deployment Error:
- **Error**: `node: --openssl-legacy-provider is not allowed in NODE_OPTIONS`
- **Cause**: Render doesn't allow legacy OpenSSL provider in NODE_OPTIONS
- **Solution**: Updated Node.js version and removed legacy provider requirement

### 📋 Changes:

**package.json**:
- ⬆️ Updated Node.js engine: `8.9.0` → `16.x`
- ⬆️ Updated npm engine: `6.4.1` → `8.x`
- 🔧 Removed `NODE_OPTIONS=--openssl-legacy-provider` from scripts
- ✅ Updated build script to `webpack --mode=production`
- ✅ Restored `postinstall` to run webpack automatically

**render.yaml**:
- 🔧 Removed `NODE_OPTIONS=--openssl-legacy-provider` from buildCommand
- ✅ Simplified to `npm run build`

### 🎯 Impact:
- ✅ Resolves Node.js compatibility issues with Render
- ✅ Webpack will build successfully without legacy provider
- ✅ App should deploy without Node.js errors
- ✅ Compatible with modern Node.js versions

### 🧪 Testing:
This fix addresses the specific error from the deployment logs:
```
node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
npm ERR! Failed at the kantrello@1.0.0 build script.
```

**Ready for immediate merge and deployment!** 🚀