### PR TITLE
Fix React bundle loading in production

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,5 +13,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-# Add SVG files to asset precompilation
-Rails.application.config.assets.precompile += %w( *.svg *.png *.jpg *.jpeg *.gif )
+# Add SVG files and webpack bundle to asset precompilation
+Rails.application.config.assets.precompile += %w( *.svg *.png *.jpg *.jpeg *.gif bundle.js )


### PR DESCRIPTION
## Summary
- Add bundle.js to Rails asset precompilation list to fix React app loading in production
- The webpack-generated bundle.js was not being precompiled, causing application.js to fail when requiring the bundle

## Test plan
- [ ] Deploy to production and verify React app loads correctly
- [ ] Confirm bundle.js is present in precompiled assets
- [ ] Test that the root page shows the React application instead of "React will render here\!"

🤖 Generated with [Claude Code](https://claude.ai/code)