### PR TITLE
Add explicit bundle.js link to Rails asset manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
+//= link bundle.js
 //= link_directory ../stylesheets .css


### PR DESCRIPTION
The bundle.js file wasn't being properly linked by the Rails asset pipeline. This adds an explicit link directive to ensure bundle.js is included in the asset compilation and available for the application.js require statement.

🤖 Generated with [Claude Code](https://claude.ai/code)