### PR TITLE
Add conditional database seeding for Render deployment

### DIFF
--- a/lib/tasks/conditional_seed.rake
+++ b/lib/tasks/conditional_seed.rake
@@ -1,0 +1,11 @@
+namespace :db do
+  desc "Conditionally seed the database if SEED_DATA=true"
+  task conditional_seed: :environment do
+    if ENV['SEED_DATA'].to_s.downcase == 'true'
+      puts "SEED_DATA=true, running db:seed..."
+      Rake::Task['db:seed'].invoke
+    else
+      puts "Skipping seeding. Set SEED_DATA=true to enable."
+    end
+  end
+end

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,7 @@ services:
       npm run build
       RAILS_ENV=production bundle exec rake assets:precompile
       RAILS_ENV=production bundle exec rake db:migrate
+      RAILS_ENV=production bundle exec rake db:conditional_seed
     startCommand: bundle exec puma -C config/puma.rb
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary
- Add rake task for conditional seeding based on SEED_DATA environment variable
- Update render.yaml to run conditional seeding after database migrations
- Enables database seeding on Render free tier without requiring shell access

## Test plan
- [ ] Deploy to Render with SEED_DATA=true to verify seeding works
- [ ] Deploy without SEED_DATA to verify seeding is skipped
- [ ] Verify existing data is properly seeded from db/seeds.rb

🤖 Generated with [Claude Code](https://claude.ai/code)